### PR TITLE
Fix sorting to target only first table

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@
         };
 
         const sortTable = columnIndex => {
-            const headers = document.querySelectorAll('th');
+            const headers = document.querySelectorAll('#excelTable th');
             const currentOrder = headers[columnSelection.indexOf(columnIndex) + 1].getAttribute('data-order');
             const newOrder = currentOrder === 'asc' ? 'desc' : 'asc';
 


### PR DESCRIPTION
## Summary
- ensure sorting function only selects headers in the first table

## Testing
- `python -m py_compile copy_sheet.py holidays.py`

------
https://chatgpt.com/codex/tasks/task_e_686d1d5a6f608326878836d917bde7a6