### PR TITLE
Fix undefined search variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,6 +378,7 @@
 
         const updateTableBody2 = (data, highlightSearch = false) => {
             const tableBody = $('excelTable2').querySelector('tbody');
+            const searchInput = $('searchInput').value.toLowerCase();
             tableBody.innerHTML = '';
 
             const rows = data.map((row, index) => {


### PR DESCRIPTION
## Summary
- initialize `searchInput` when updating the secondary table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d1e0f9b5c83269039fb80c2322810